### PR TITLE
Fix fromString of MatchUtils OFVlanVidMatch issue

### DIFF
--- a/src/main/java/net/floodlightcontroller/util/MatchUtils.java
+++ b/src/main/java/net/floodlightcontroller/util/MatchUtils.java
@@ -444,11 +444,11 @@ public class MatchUtils {
 				break;
 			case STR_DL_VLAN:
 				if (dataMask.length == 1) {
-					mb.setExact(MatchField.VLAN_VID, OFVlanVidMatch.ofVlan(dataMask[0].contains("0x") ? Integer.valueOf(dataMask[0].replaceFirst("0x", ""), 16) : Integer.valueOf(dataMask[0])));
+					mb.setExact(MatchField.VLAN_VID, OFVlanVidMatch.ofRawVid(dataMask[0].contains("0x") ? Short.valueOf(dataMask[0].replaceFirst("0x", ""), 16) : Short.valueOf(dataMask[0])));
 				} else {
 					mb.setMasked(MatchField.VLAN_VID, OFVlanVidMatchWithMask.of(
-						OFVlanVidMatch.ofVlan(dataMask[0].contains("0x") ? Integer.valueOf(dataMask[0].replaceFirst("0x", ""), 16) : Integer.valueOf(dataMask[0])), 
-						OFVlanVidMatch.ofVlan(dataMask[1].contains("0x") ? Integer.valueOf(dataMask[1].replaceFirst("0x", ""), 16) : Integer.valueOf(dataMask[1]))));
+						OFVlanVidMatch.ofRawVid(dataMask[0].contains("0x") ? Short.valueOf(dataMask[0].replaceFirst("0x", ""), 16) : Short.valueOf(dataMask[0])), 
+						OFVlanVidMatch.ofRawVid(dataMask[1].contains("0x") ? Short.valueOf(dataMask[1].replaceFirst("0x", ""), 16) : Short.valueOf(dataMask[1]))));
 				}
 				break;
 			case STR_DL_VLAN_PCP:


### PR DESCRIPTION
String in dataMask vid like this: "0x1001"  (including the PRESENT_BIT), which means valnID = 1
OFVlanVidMatch.ofVlan(int vid) requires vid value between 0~4096 ( not including the PRESENT_BIT)
it causes IllegalArgumentException:  Illegal VLAN value: 1001

So I change it into OFVlanVidMatch.ofRawVlan(short) 
OFVlanVidMatch.ofVlan(dataMask[0].contains("0x") ? Integer.valueOf(dataMask[0].replaceFirst("0x", ""), 16)

Scenario:
net.floodlightcontroller.staticflowentry.StaticFlowEntries.java
Line236~244
set  String for MatchField.VLAN_VID =  match.get(MatchField.VLAN_VID).toString()
OFVlanVidMatch.toString()  returns vid with PRESENT_BIT ( "0x1001")

and then in 
net.floodlightcontroller.staticflowentry.StaticFlowEntryPusher.java
Line 431
fmb.setMatch(MatchUtils.fromString(match, fmb.getVersion()));
calls MatchUtils.fromString

dataMask String for MatchField.VLAN_VID  is "0x1001"
which causes IllegalArgumentException:  Illegal VLAN value: 1001
while using OFVlanVidMatch.ofVlan(hex(1001))   to create OFVlanVidMatch
